### PR TITLE
New DAQ version

### DIFF
--- a/config/config_nfv.sh
+++ b/config/config_nfv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DAQ_VERSION="2.0.6"
+DAQ_VERSION="2.0.7"
 
 # Install required packages 
 sudo apt-get update


### PR DESCRIPTION
Hi,

I had to change the latest snort daq version to get the demo up and running.
Version 2.0.6 is archived, and therefore the snort application can not be installed anymore.
It would also be possible to change the link in the config file to: 
```
https://www.snort.org/downloads/archive/snort/daq-${DAQ_VERSION}.tar.gz
```
The demo seems to work without any problems with the new daq version.

Best 
Severin